### PR TITLE
Just split the URL not the filter

### DIFF
--- a/grimoire_elk_gitee/raw/gitee.py
+++ b/grimoire_elk_gitee/raw/gitee.py
@@ -60,6 +60,9 @@ class GiteeOcean(ElasticOcean):
 
         params = []
 
+        tokens = url.split(' ', 1)  # Just split the URL not the filter
+        url = tokens[0]
+
         owner = url.split('/')[-2]
         repository = url.split('/')[-1]
         params.append(owner)


### PR DESCRIPTION
Fix the scene : the input url is `https://gitee.com/xxx/xxx --filter-xx=xx`, the return repository will be wrong.

Signed-off-by: Fugang Xiao <xiao623@outlook.com>